### PR TITLE
Fix layout on small screens

### DIFF
--- a/src/pages/datenschutz.tsx
+++ b/src/pages/datenschutz.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'gatsby';
 import Button from '../components/ButtonLink';
+import Layout from '../components/Layout';
 import { Image as ArrowIcon } from '../images/arrow-left.svg';
 
 const ExternalLink = ({ href }: { href: string }) => (
@@ -15,9 +16,9 @@ const ExternalLink = ({ href }: { href: string }) => (
 )
 
 const PrivacyPage = (): JSX.Element => (
-    <>
+    <Layout>
         <main className="max-w-prose mx-auto font-body leading-relaxed">
-            <h1 className="font-display text-5xl text-pink-500 font-light mt-20">Datenschutzerklärung</h1>
+            <h1 className="font-display text-5xl text-pink-500 font-light mt-20">Datenschutz&shy;erklärung</h1>
 
             <h2 className="text-2xl text-sky-500 mt-12 mb-6">Verantwortlicher</h2>
 
@@ -145,7 +146,7 @@ const PrivacyPage = (): JSX.Element => (
         <footer className="mx-auto text-center mb-20 mt-10">
             <Button href="/" icon={<ArrowIcon />}>Zurück</Button>
         </footer>
-    </>
+    </Layout>
 );
 
 export default PrivacyPage;

--- a/src/pages/impressum.tsx
+++ b/src/pages/impressum.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Link } from 'gatsby';
 import Button from '../components/ButtonLink';
+import Layout from '../components/Layout';
 import { Image as ArrowIcon } from '../images/arrow-left.svg';
 
 const ImprintPage = (): JSX.Element => (
-    <>
+    <Layout>
         <main className="max-w-prose mx-auto font-body leading-relaxed">
             <h1 className="font-display text-5xl text-pink-500 font-light mt-20">Impressum</h1>
 
@@ -35,7 +36,7 @@ const ImprintPage = (): JSX.Element => (
         <footer className="mx-auto text-center mb-20 mt-10">
             <Button href="/" icon={<ArrowIcon />}>Zurück</Button>
         </footer>
-    </>
+    </Layout>
 );
 
 export default ImprintPage;


### PR DESCRIPTION
The imprint and privacy pages look ugly on small screns like
smartphones. Wrapping them with the Layout component fixes this. Additionally
it adds the footer which gives a recognizable effect.